### PR TITLE
Fix `ModuleNotFoundError: No module named 'mitmproxy.tools._main'`

### DIFF
--- a/http_tools/modules/runner.py
+++ b/http_tools/modules/runner.py
@@ -6,7 +6,7 @@ import os
 from mitmproxy.tools import (
     cmdline,
     dump)
-from mitmproxy.tools._main import run
+from mitmproxy.tools.main import run
 
 import http_tools.settings as settings
 


### PR DESCRIPTION
Hello,

It's causing python-http-tools to fail because a typo.